### PR TITLE
Creates GET api/v1/recipes/calorie_count Endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@ Introduction: This is the paired project from Mod 4 at Turing School of Software
 Github Projects board is available at https://github.com/Matt-Weiss/quantified-self/projects/1 in conjunction with the Quantified Self repository.
 
 Initial Setup:
+Clone repository
+Run npm install
+npx knex migrate:latest
+
 
 How to Use:
 

--- a/db/migrations/20190705111445_add_yield.js
+++ b/db/migrations/20190705111445_add_yield.js
@@ -3,6 +3,7 @@ exports.up = function(knex) {
   return Promise.all([
     knex.schema.table('recipes', function(table) {
       table.string('yield');
+      table.integer('caloriesPerServing');
     })
   ])
 };

--- a/db/seeds/dev/recipes.js
+++ b/db/seeds/dev/recipes.js
@@ -8,6 +8,8 @@ exports.seed = function(knex) {
         {id: 1, foodType: "chicken",
               recipeName: "Citrus Roasted Chicken",
                 calories: 2643,
+                   yield: 4,
+      caloriesPerServing: 661,
                recipeUrl: "https://food52.com/recipes/3403-citrus-roasted-chicken",
           numIngredients: 6,
        ingredientsString: "1 chicken, about 3.5 to 4 pounds \n 1 lemon \n 1 blood orange \n 1 tangerine or clementine \n Kosher salt \n 1/2 cup chicken broth"
@@ -16,6 +18,7 @@ exports.seed = function(knex) {
                recipeName: "Roast Chicken",
                  calories: 2384,
                     yield: 4,
+       caloriesPerServing: 596,
                 recipeUrl: "http://www.epicurious.com/recipes/food/views/Roast-Chicken-394676",
            numIngredients: 3,
         ingredientsString: "1 tablespoon kosher salt \n 1 whole 4-pound chicken, giblets reserved for another use \n 1/4 cup (1/2 stick) unsalted butter, melted"
@@ -24,6 +27,7 @@ exports.seed = function(knex) {
                recipeName: "Thomato Chicken",
                  calories: 2027,
                     yield: 3,
+       caloriesPerServing: 676,
                 recipeUrl: "http://www.bbcgoodfood.com/recipes/94602/thomato-chicken",
            numIngredients: 12,
         ingredientsString: "2 chicken breasts \n 2 tsp capers \n 1 large onion \n 6 cherry tomatoes \n 1.5 tsp oregano \n 3 tsps of tomato puree \n 1 red pepper \n 1 tin chopped tomatoes \n 5 sun-dried tomatoes \n 1 tsp basil \n Salt and pepper to taste \n Olive oil for frying chicken"
@@ -32,6 +36,7 @@ exports.seed = function(knex) {
                recipeName: "Chicken Paprika",
                  calories: 3804,
                     yield: 6,
+       caloriesPerServing: 634,
                 recipeUrl: "http://www.bbc.co.uk/food/recipes/chickenpaprikawithle_80341",
            numIngredients: 14,
         ingredientsString: "1 large chicken, jointed (or use 2 large chicken legs and 2 breasts, halved) \n Salt \n 2 tbsp olive oil \n Knob butter \n 1 onion, chopped \n 2-3 cloves garlic, chopped \n 1 tbsp sweet paprika \n 1 tbsp hot paprika \n 1 tbsp flour \n 285ml/½pint chicken stock \n 3 tbsp chopped fresh flatleaf parsley \n 2 red peppers, de-seeded and cut into 1cm/0.5in strips \n 4 large ripe tomatoes, roughly chopped \n 250ml/8fl oz sour cream"
@@ -40,6 +45,7 @@ exports.seed = function(knex) {
                recipeName: "Circassian Chicken",
                  calories: 2808,
                     yield: 4,
+       caloriesPerServing: 702,
                 recipeUrl: "http://simplyrecipes.com/recipes/circassian_chicken/",
            numIngredients: 13,
         ingredientsString:  "2 full chicken breasts (both halves) /n 4 tablespoons olive or walnut oil /n 4 teaspoons paprika /n 1 ½ cups chopped walnuts /n 3 chopped garlic cloves /n 2 tablespoons chopped green onions /n 1 teaspoon cayenne /n 2 tablespoons chopped parsley /n 2 slices of bread, crusts removed /n 1 quart chicken stock /n Salt /n Black pepper /n The juice of a lemon"
@@ -48,6 +54,7 @@ exports.seed = function(knex) {
                recipeName: "Baked Enchilada Chicken",
                  calories: 3604,
                     yield: 6,
+       caloriesPerServing: 601,
                 recipeUrl: "http://www.kitchendaily.com/recipe/baked-enchilada-chicken",
            numIngredients: 2,
         ingredientsString: "3 ½ lb chicken parts /n 1 cup prepared enchilada sauce"
@@ -56,6 +63,7 @@ exports.seed = function(knex) {
                recipeName: "Teriyaki Chicken",
                  calories: 2618,
                     yield: 4,
+       caloriesPerServing: 655,
                 recipeUrl: "https://www.realsimple.com/food-recipes/browse-all-recipes/teriyaki-chicken",
            numIngredients: 4,
         ingredientsString: "1  3 1/2- to 4-pound chicken, cut into pieces /n 1/2 cup bottled teriyaki sauce /n 1 teaspoon kosher salt /n 1/2 teaspoon black pepper"
@@ -64,6 +72,7 @@ exports.seed = function(knex) {
                recipeName: "Cracklin’ Chicken",
                  calories: 2709,
                     yield: 4,
+       caloriesPerServing: 677,
                 recipeUrl: "http://nomnompaleo.com/post/74180911762/cracklin-chicken",
            numIngredients: 4,
         ingredientsString: "8 bone-in, skin-on chicken thighs (approximately 4 pounds) /n 1 tablespoon Diamond Crystal kosher salt /n 2 teaspoons ghee /n 2 teaspoons seasoning blend of choice (optional)"
@@ -72,6 +81,7 @@ exports.seed = function(knex) {
                recipeName: "Chicken And Dumplings Recipe",
                  calories: 5172,
                     yield: 8,
+       caloriesPerServing: 647,
                 recipeUrl: "http://www.foodrepublic.com/2011/06/19/chicken-and-dumplings-recipe",
            numIngredients: 9,
         ingredientsString: "12 cups chicken broth /n 1 rotisserie chicken /n 3 cups self-rising flour, plus more for countertop /n 1/8 teaspoon dried sage /n 1/8 teaspoon dried thyme /n 1/4 teaspoon dried oregano /n 1/4 teaspoon freshly ground black pepper /n 6 tablespoons Crisco shortening /n 1 cup milk"
@@ -80,6 +90,7 @@ exports.seed = function(knex) {
                 recipeName: "Chicken & Peppers",
                   calories: 1197,
                      yield: 2,
+        caloriesPerServing: 599,
                  recipeUrl: "http://thestonesoup.com/blog/2012/05/the-1-thing-you-should-never-do-when-combining-flavours/",
             numIngredients: 2,
          ingredientsString: "4-6 chicken drumsticks /n 2-3 large red capsicum (bell peppers), chopped"
@@ -88,6 +99,7 @@ exports.seed = function(knex) {
                recipeName: "Grilled And Roasted Beef",
                  calories: 3801,
                     yield: 6,
+       caloriesPerServing: 634,
                 recipeUrl: "http://ruhlman.com/2011/12/grill-roast-beef-recipe/",
            numIngredients: 4,
         ingredientsString: "One 6-pound/2.7-kilogram rack of beef /n Kosher salt /n” 2 tablespoons canola or olive oil /n 2 teaspoons coarsely cracked or chopped black pepper /n 2 teaspoons coarsely cracked coriander seeds"
@@ -96,6 +108,7 @@ exports.seed = function(knex) {
                recipeName: "Grilled Beef Tenderloin",
                  calories: 5389,
                     yield: 8,
+       caloriesPerServing: 674,
                 recipeUrl: "http://www.marthastewart.com/319496/grilled-beef-tenderloin",
            numIngredients: 4,
         ingredientsString: "1 beef tenderloin (4 pounds), preferably grass fed (estanciabeef.com), trimmed and tied /n Extra-virgin olive oil, for rubbing /n Coarse salt and freshly ground pepper /n 1/2 cup mint-chive butter"
@@ -104,6 +117,7 @@ exports.seed = function(knex) {
                 recipeName: "Beef Stew",
                   calories: 2582,
                      yield: 4,
+        caloriesPerServing: 646,
                  recipeUrl: "http://www.epicurious.com/recipes/food/views/Beef-Stew-358272",
             numIngredients: 12,
          ingredientsString: "1/2 cup flour /n 1 teaspoon salt /n 1/4 teaspoon pepper /n 2 pounds stew beef, cubed /n 3 teaspoons olive oil or butter /n 1 bay leaf /n 1 clove garlic, smashed /n 1 beef stock cube /n 1 pound small onions /n 6 carrots, sliced /n 3 medium-size potatoes, quartered /n 1 package frozen peas"
@@ -112,6 +126,7 @@ exports.seed = function(knex) {
                 recipeName: "Beef Wellington Recipe",
                   calories: 3803,
                      yield: 6,
+        caloriesPerServing: 634,
                  recipeUrl: "http://www.foodrepublic.com/2011/12/21/beef-wellington-recipe",
             numIngredients: 10,
          ingredientsString: "2 1/2 pounds beef tenderloin /n 2 tablespoons olive oil /n 3 tablespoons butter /n 1 1/2 cups button mushrooms, quartered /n 1 cup porcini mushrooms, quartered /n 5 shallots peeled and finely chopped /n 1 small bunch parsley /n 2 slices sandwich bread, torn into pieces /n puff pastry /n 1 egg yolk /n"
@@ -120,6 +135,7 @@ exports.seed = function(knex) {
                 recipeName: "Quick Beef Tacos",
                   calories: 2880,
                      yield: 4,
+        caloriesPerServing: 721,
                  recipeUrl: "https://www.realsimple.com/food-recipes/browse-all-recipes/beef-tacos-recipe",
             numIngredients: 8,
          ingredientsString: "1 1/2 pounds ground beef /n 1 teaspoon ground cumin /n 1 1/2 cups jarred salsa /n kosher salt /n 8  taco shells /n 1  avocado, diced /n 1/2 cup sour cream /n 1 cup fresh cilantro"
@@ -128,6 +144,7 @@ exports.seed = function(knex) {
                 recipeName: "Quick Beef Stroganoff",
                   calories: 2379,
                      yield: 4,
+        caloriesPerServing: 595,
                  recipeUrl: "http://www.myrecipes.com/recipe/quick-beef-stroganoff-3",
             numIngredients: 9,
          ingredientsString: "2 tablespoons  extra-virgin olive oil /n 1   onion, thinly sliced /n 8 ounces  cremini mushrooms, thinly sliced /n 1 teaspoon  chopped thyme /n Kosher salt and freshly ground pepper /n 1 cup  reserved gravy from Coriander-Dusted Roast Beef or other beef gravy /n 1/4 cup  sour cream /n Half of the Coriander-Dusted Roast Beef or 12 ounces roast beef, sliced 1/4 inch thick and cut into strips /n Buttered noodles, for serving"
@@ -136,6 +153,7 @@ exports.seed = function(knex) {
                recipeName: "Seared Beef and Noodle Soup",
                  calories: 2502,
                     yield: 4,
+       caloriesPerServing: 626,
                 recipeUrl: "http://www.pbs.org/food/recipes/seared-beef-and-noodle-soup/",
            numIngredients: 13,
         ingredientsString: "1/2 lb. rice noodles /n 1 1/4 lbs. beef sirloin (about 1 inch thick) /n Salt and pepper /n 2 tablespoons olive oil /n 10 ounces white mushrooms sliced /n 2 cloves garlic minced /n 6 cups beef stock or reduced-sodium canned broth /n 3 tablespoons soy sauce /n 2 teaspoons rice-wine vinegar /n 2 carrots cut into thin strips /n 1/2 napa cabbage shredded /n 2 scallions including green parts, thinly sliced /n 1 cup bean sprouts"
@@ -144,6 +162,7 @@ exports.seed = function(knex) {
                recipeName: "Beef and Noodles",
                  calories: 4236,
                     yield: 6,
+       caloriesPerServing: 706,
                 recipeUrl: "https://www.foodnetwork.com/recipes/beef-and-noodles-recipe-2012887",
            numIngredients: 14,
         ingredientsString: "8 ounces beef bones /n 1/3 pound carrots, coarsely chopped /n 1/3 pound celery, coarsely chopped /n 1/3 pound yellow onion, coarsely chopped /n 1 ounce instant au jus powder or 5 beef bouillon cubes, crushed /n 1/2 teaspoon granulated garlic /n 2 pounds beef roast, inside round or top round /n 8 cups beef stock /n 3 1/2 cups all-purpose flour, plus for dusting /n 1 teaspoon salt /n 2 eggs /n 4 egg yolks /n 2 teaspoons oil /n Salt and freshly ground black pepper"
@@ -152,6 +171,7 @@ exports.seed = function(knex) {
                recipeName: "Plum-Spiced Beef Brisket",
                  calories: 5326,
                     yield: 8,
+       caloriesPerServing: 666,
                 recipeUrl: "http://www.goodhousekeeping.com/food-recipes/a5861/plum-spiced-beef-brisket-3144/",
            numIngredients: 14,
         ingredientsString: "3 tbsp. toasted sesame oil /n 3½ lb. beef brisket /n 2 tsp. salt /n 1 tsp. fresh ground pepper /n 4 can low-sodium beef broth /n 2 c. dried plums /n 1/2 c. Worcestershire sauce /n 1/2 c. low-sodium soy sauce /n 6 clove garlic /n 2 tbsp. finely chopped ginger /n 2 tbsp. dark brown sugar /n 2 tbsp. apple-cider vinegar /n 1 tsp. five-spice powder /n 1/2 tsp. crushed red pepper"
@@ -160,6 +180,7 @@ exports.seed = function(knex) {
               recipeName: "Goan Beef and Chili Stir Fry",
                 calories: 2555,
                    yield: 4,
+      caloriesPerServing: 639,
                recipeUrl: "http://honestcooking.com/goan-beef-and-chili-stir-fry/",
           numIngredients: 9,
        ingredientsString: "2 lbs cubed beef (stew beef pieces preferably) /n 4 medium sized potatoes /n 2 large red onions /n 2 cloves of garlic /n 1 teaspoon grated ginger root /n 1 teaspoon garam masala /n 4 medium sized green chilies /n Salt and pepper to taste /n 4 tablespoons vegetable oil"
@@ -168,6 +189,7 @@ exports.seed = function(knex) {
               recipeName: "Easy Pork Shoulder",
                 calories: 5644,
                    yield: 9,
+      caloriesPerServing: 627,
                recipeUrl: "http://www.marthastewart.com/343825/easy-pork-shoulder",
           numIngredients: 4,
        ingredientsString: "1 boneless pork shoulder (7 pounds) /n coarse salt /n“ ground pepper /n 1/2 cup water /n"
@@ -176,6 +198,7 @@ exports.seed = function(knex) {
               recipeName: "Flæskesteg - Danish Roast Pork",
                 calories: 2772,
                    yield: 4,
+      caloriesPerServing: 693,
                recipeUrl: "http://honestcooking.com/flaeskesteg-danish-roast-pork-recipe/",
           numIngredients: 4,
        ingredientsString: "1 5-lb. slab of pork tenderloin, with rind and fat intact /n Dried bay leaves /n Whole cloves /n Sea salt and pepper"
@@ -184,6 +207,7 @@ exports.seed = function(knex) {
               recipeName: "Double-Pork Carnitas",
                 calories: 5653,
                    yield: 8,
+      caloriesPerServing: 707,
                recipeUrl: "https://www.epicurious.com/recipes/food/views/pork-carnitas-tacos",
           numIngredients: 12,
        ingredientsString: "3 pounds boneless pork shoulder (Boston butt), cut into 1 1/2-inch pieces /n 1 pound pork belly, cut into 1-inch pieces /n 1 cup homemade chicken stock or low-sodium chicken broth /n 1 tablespoon (heaping) kosher salt /n 1 teaspoon freshly ground black pepper /n Warm corn tortillas, chopped white onion, lime wedges, sliced avocado, dried oregano, chopped cilantro, and shredded cabbage (for serving)"
@@ -192,6 +216,7 @@ exports.seed = function(knex) {
               recipeName: "Pork With Creamy Pear Sauce",
                 calories: 2649,
                    yield: 4,
+      caloriesPerServing: 662,
                recipeUrl: "http://www.bbcgoodfood.com/recipes/13456/pork-with-creamy-pear-sauce",
           numIngredients: 7,
        ingredientsString: "350 ml cream /n 3 spring onions, finely sliced /n 1 pear, diced /n Salt and pepper /n 1 tbsp butter or margarine /n 1 tbsp extra-virgin olive oil /n 900 g pork tenderloin"
@@ -200,6 +225,7 @@ exports.seed = function(knex) {
               recipeName: "Pork Vindaloo",
                 calories: 2519,
                    yield: 4,
+      caloriesPerServing: 629,
                recipeUrl: "https://food52.com/recipes/1739-pork-vindaloo",
           numIngredients: 15,
        ingredientsString: "1 1/2 pound pork /n 1 teaspoon cumin /n 1/4 teaspoon turmeric /n 2 teaspoons mustard /n 1 pod garlic /n 1 inch ginger /n 4 dry red chilly (remove seed) /n 4 clove /n 1 inch stick cinnamon /n 1 teaspoon pepper /n 1 tablespoon raisin /n 1 teaspoon sugar /n 1/2 cup cider vinegar /n 3/4 pounds tomato /n 1/2 cup oil"
@@ -208,6 +234,7 @@ exports.seed = function(knex) {
               recipeName: "Juicy Buttermilk Pork Chops",
                 calories: 2383,
                    yield: 4,
+      caloriesPerServing: 596,
                recipeUrl: "http://www.kitchendaily.com/recipe/juicy-buttermilk-pork-chops",
           numIngredients: 4,
        ingredientsString: "4 1-inch thick bone-in pork rib chops, about 12 ounce each /n 1 qt buttermilk /n salt and freshly ground black pepper /n 2 Tbsp extra virgin olive oil"
@@ -216,6 +243,7 @@ exports.seed = function(knex) {
               recipeName: "Sweet And Tangy Pork Chops",
                 calories: 2445,
                    yield: 4,
+      caloriesPerServing: 611,
                recipeUrl: "http://www.cookstr.com/recipes/sweet-and-tangy-pork-chops",            numIngredients: 4,
        ingredientsString: "1/2 cup Neely's Barbecue Seasoning /n 2 cups Neely’s Barbecue Sauce /n Four 1-inch-thick bone-in center-cut pork chops /n Kosher salt"
        },
@@ -223,6 +251,7 @@ exports.seed = function(knex) {
               recipeName: "Indoor Pulled Pork",
                 calories: 3763,
                    yield: 6,
+      caloriesPerServing: 627,
                recipeUrl: "http://www.thebittenword.com/thebittenword/2010/01/indoor-pulled-pork-and-other-superbowl-food-ideas.html",
           numIngredients: 8,
        ingredientsString: "1 cup plus 2 tsps table salt /n 1/2 cup plus 2 tbsps sugar /n 3 tbsps plus 2 tsps liquid smoke /n 1 boneless pork butt (about 5 lbs), cut in half horizontally /n 1/4 cup yellow mustard /n 2 tbsps ground black pepper /n 2 tbsps smoked paprika /n 1 tsp cayenne pepper"
@@ -231,6 +260,7 @@ exports.seed = function(knex) {
               recipeName: "Braised Hawaiian Pork Shoulder",
                 calories: 2566,
                    yield: 4,
+      caloriesPerServing: 642,
                recipeUrl: "http://www.cookingchanneltv.com/recipes/brian-boitano/braised-hawaiian-pork-shoulder.html",
           numIngredients: 13,
        ingredientsString: "1 tablespoon brown sugar /n 2 teaspoons red hawaiian sea salt or kosher salt /n 2 teaspoons paprika /n 1/2 teaspoon ground cumin /n 1/2 teaspoon ground coriander /n 1/2 teaspoon freshly cracked black pepper /n 1 1/2 pounds pork shoulder or boston pork butt /n 1/4 cup canola oil, divided /n 1 onion, chopped /n 1 (3-inch) piece ginger, sliced /n 4 cloves garlic, smashed /n 1 cup pineapple juice /n 2 cups chicken stock or broth"
@@ -239,6 +269,7 @@ exports.seed = function(knex) {
               recipeName: "Fennel and Chili-Rubbed Pork Roast",
                 calories: 4861,
                    yield: 8,
+      caloriesPerServing: 608,
                recipeUrl: "http://www.thedailymeal.com/recipes/fennel-and-chili-rubbed-pork-roast-recipe",
           numIngredients: 5,
        ingredientsString: "5 Pounds pork ribeye roast, or bone-in pork loin roast /n Sea salt, to taste /n 1/3  Cup fennel seed, toasted /n 1 1/2 Tablespoon red chili flake, toasted /n 2 Tablespoons olive oil"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,16 @@
         "negotiator": "0.6.2"
       }
     },
+    "ansi-regex": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
+      "integrity": "sha1-DY6UaWej2BQ/k+JOKYUl/BsiNfk="
+    },
+    "ansi-styles": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
+      "integrity": "sha1-6uy/Zs1waIJ2Cy9GkVgrj1XXp94="
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -116,6 +126,19 @@
         "safe-buffer": "5.1.2"
       }
     },
+    "bindings": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.2.1.tgz",
+      "integrity": "sha1-FK1hE4EtLTfXLme0ystLtyZQXxE="
+    },
+    "bl": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-0.4.2.tgz",
+      "integrity": "sha1-XbMdcvA4xU5orcOVeBJf47Ct3JY=",
+      "requires": {
+        "readable-stream": "~1.0.2"
+      }
+    },
     "bluebird": {
       "version": "3.5.5",
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
@@ -191,6 +214,18 @@
         "unset-value": "^1.0.0"
       }
     },
+    "chalk": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+      "integrity": "sha1-Zjs6ZItotV0EaQ1JFnqoN4WPIXQ=",
+      "requires": {
+        "ansi-styles": "^1.1.0",
+        "escape-string-regexp": "^1.0.0",
+        "has-ansi": "^0.1.0",
+        "strip-ansi": "^0.3.0",
+        "supports-color": "^0.2.0"
+      }
+    },
     "class-utils": {
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
@@ -211,6 +246,11 @@
           }
         }
       }
+    },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -269,6 +309,20 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+    },
+    "deasync": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/deasync/-/deasync-0.1.15.tgz",
+      "integrity": "sha512-pxMaCYu8cQIbGkA4Y1R0PLSooPIpH1WgFBLeJ+zLxQgHfkZG86ViJSmZmONSjZJ/R3NjwkMcIWZAzpLB2G9/CA==",
+      "requires": {
+        "bindings": "~1.2.1",
+        "node-addon-api": "^1.6.0"
+      }
     },
     "debug": {
       "version": "2.6.9",
@@ -349,6 +403,11 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "etag": {
       "version": "1.8.1",
@@ -639,6 +698,14 @@
         "ini": "^1.3.4",
         "is-windows": "^1.0.1",
         "which": "^1.2.14"
+      }
+    },
+    "has-ansi": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+      "integrity": "sha1-hPJlqujA5qiKEtcCKJS3VoiUxi4=",
+      "requires": {
+        "ansi-regex": "^0.2.0"
       }
     },
     "has-value": {
@@ -1072,6 +1139,11 @@
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.2.tgz",
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
+    "node-addon-api": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-1.6.3.tgz",
+      "integrity": "sha512-FXWH6mqjWgU8ewuahp4spec8LkroFZK2NicOv6bNwZC3kcwZUI8LeZdG80UzTSLLhK4T7MsgNwlYDVRlDdfTDg=="
+    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -1099,6 +1171,11 @@
           }
         }
       }
+    },
+    "object-keys": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+      "integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
     },
     "object-visit": {
       "version": "1.0.1",
@@ -1295,6 +1372,27 @@
         "ipaddr.js": "1.9.0"
       }
     },
+    "pryjs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/pryjs/-/pryjs-1.0.3.tgz",
+      "integrity": "sha1-msqACY7l3edrenu2047CrHIJR80=",
+      "requires": {
+        "chalk": "^0.5.1",
+        "coffee-script": "^1.8.0",
+        "deasync": "~0.1.2",
+        "pygmentize-bundled": "^2.3.0",
+        "underscore": "^1.7.0"
+      }
+    },
+    "pygmentize-bundled": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pygmentize-bundled/-/pygmentize-bundled-2.3.0.tgz",
+      "integrity": "sha1-1CXe2o0TaXW5M+3jYxNfYjNQgUo=",
+      "requires": {
+        "bl": "~0.4.1",
+        "through2": "~0.2.1"
+      }
+    },
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
@@ -1314,6 +1412,24 @@
         "http-errors": "1.6.3",
         "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "1.0.34",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+      "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        }
       }
     },
     "rechoir": {
@@ -1609,6 +1725,24 @@
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
       "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
     },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+    },
+    "strip-ansi": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+      "integrity": "sha1-JfSOoiynkYfzF0pNuHWTR7sSYiA=",
+      "requires": {
+        "ansi-regex": "^0.2.1"
+      }
+    },
+    "supports-color": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
+      "integrity": "sha1-2S3iaU6z9nMjlz1649i1W0wiGQo="
+    },
     "tarn": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/tarn/-/tarn-1.1.5.tgz",
@@ -1618,6 +1752,41 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+    },
+    "through2": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/through2/-/through2-0.2.3.tgz",
+      "integrity": "sha1-6zKE2k6jEbbMis42U3SKUqvyWj8=",
+      "requires": {
+        "readable-stream": "~1.1.9",
+        "xtend": "~2.1.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
+        },
+        "xtend": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+          "integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+          "requires": {
+            "object-keys": "~0.4.0"
+          }
+        }
+      }
     },
     "tildify": {
       "version": "2.0.0",
@@ -1675,6 +1844,11 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/unc-path-regex/-/unc-path-regex-0.1.2.tgz",
       "integrity": "sha1-5z3T17DXxe2G+6xrCufYxqadUPo="
+    },
+    "underscore": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "union-value": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "express": "~4.16.1",
     "knex": "^0.18.3",
     "morgan": "~1.9.1",
-    "pg": "^7.11.0"
+    "pg": "^7.11.0",
+    "pryjs": "^1.0.3"
   },
   "main": "app.js",
   "devDependencies": {},

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -12,4 +12,14 @@ router.get("/", function (req, res, next) {
     });
 })
 
+router.get("/calorie_count", function (req, res, next) {
+  knex('recipes').whereBetween('caloriesPerServing', [req.query.from, req.query.to])
+    .then((recipes) => {
+      res.status(200).json({results: recipes.length, recipes: recipes});
+    })
+    .catch((error) => {
+      res.status(500).json({ error });
+    });
+})
+
 module.exports = router;

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -15,7 +15,11 @@ router.get("/", function (req, res, next) {
 router.get("/calorie_count", function (req, res, next) {
   knex('recipes').whereBetween('caloriesPerServing', [req.query.from, req.query.to])
     .then((recipes) => {
-      res.status(200).json({results: recipes.length, recipes: recipes});
+      if (recipes.length > 0) {
+        res.status(200).json({results: recipes.length, recipes: recipes});
+      } else {
+        res.status(404).json("No recipes within that calorie range!");
+      }
     })
     .catch((error) => {
       res.status(500).json({ error });


### PR DESCRIPTION
This pull request includes the creation of a calorie_count endpoint that takes 2 params, from & to, which displays all recipes that fall between the range in the column caloriesPerServing. 

Sample request URL: /api/v1/recipes/calorie_count?from=500&to=700

I added caloriesPerServing to the database, my thought process here was that it would be more efficient to calculate this number once upon record creation rather than dividing calories / yield every time someone hit the calorie_count endpoint. 

Response includes a hash with the keys results (returns total number of recipes) and recipes (an array of all applicable recipes). 