### PR TITLE
GET /api/v1/recipes?column='columnName'&order='asc/desc'

### DIFF
--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -12,4 +12,14 @@ router.get("/", function (req, res, next) {
     });
 })
 
+router.get("/food_search", function (req, res, next) {
+  knex('recipes').where('foodType', req.query.foodType)
+    .then((recipes) => {
+      res.status(200).json(recipes);
+    })
+    .catch((error) => {
+      res.status(500).json({ error });
+    });
+})
+
 module.exports = router;

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -3,13 +3,28 @@ var router = express.Router();
 var knex = require('../../../db/knex.js');
 
 router.get("/", function (req, res, next) {
-  knex('recipes').orderBy(req.query.columnName, req.query.order)
-  .then((recipes) => {
-    res.status(200).json(recipes);
-  })
-  .catch((error) => {
-    res.status(500).json({ error });
-  });
+  if (req.query.order){
+    var sortOrder = req.query.order
+  } else {
+    var sortOrder = 'asc'
+  }
+  if (req.query.columnName){
+    knex('recipes').orderBy(req.query.columnName, sortOrder)
+    .then((recipes) => {
+      res.status(200).json(recipes);
+    })
+    .catch((error) => {
+      res.status(500).json({ error });
+    });
+  } else {
+    knex('recipes').select()
+    .then((recipes) => {
+      res.status(200).json(recipes);
+    })
+    .catch((error) => {
+      res.status(500).json({ error });
+    });
+  }
 })
 
 router.get("/food_search", function (req, res, next) {

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -15,7 +15,11 @@ router.get("/", function (req, res, next) {
 router.get("/food_search", function (req, res, next) {
   knex('recipes').where('foodType', req.query.foodType)
     .then((recipes) => {
-      res.status(200).json(recipes);
+      if (recipes.length > 0) {
+        res.status(200).json(recipes);
+      } else {
+        res.status(404).json({error: "No recipes with that food type!"})
+      }
     })
     .catch((error) => {
       res.status(500).json({ error });

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -3,27 +3,27 @@ var router = express.Router();
 var knex = require('../../../db/knex.js');
 
 router.get("/", function (req, res, next) {
-  knex('recipes').select()
-    .then((recipes) => {
-      res.status(200).json(recipes);
-    })
-    .catch((error) => {
-      res.status(500).json({ error });
-    });
+  knex('recipes').orderBy(req.query.columnName, req.query.order)
+  .then((recipes) => {
+    res.status(200).json(recipes);
+  })
+  .catch((error) => {
+    res.status(500).json({ error });
+  });
 })
 
 router.get("/food_search", function (req, res, next) {
   knex('recipes').where('foodType', req.query.foodType)
-    .then((recipes) => {
-      if (recipes.length > 0) {
-        res.status(200).json(recipes);
-      } else {
-        res.status(404).json({error: "No recipes with that food type!"})
-      }
-    })
-    .catch((error) => {
-      res.status(500).json({ error });
-    });
+  .then((recipes) => {
+    if (recipes.length > 0) {
+      res.status(200).json(recipes);
+    } else {
+      res.status(404).json({error: "No recipes with that food type!"})
+    }
+  })
+  .catch((error) => {
+    res.status(500).json({ error });
+  });
 })
 
 module.exports = router;

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -3,28 +3,31 @@ var router = express.Router();
 var knex = require('../../../db/knex.js');
 
 router.get("/", function (req, res, next) {
-  if (req.query.order){
-    var sortOrder = req.query.order
+  if (req.query.order == 'desc'){
+    var sortOrder = 'desc'
   } else {
     var sortOrder = 'asc'
   }
-  if (req.query.columnName){
-    knex('recipes').orderBy(req.query.columnName, sortOrder)
-    .then((recipes) => {
-      res.status(200).json(recipes);
-    })
-    .catch((error) => {
-      res.status(500).json({ error });
-    });
-  } else {
-    knex('recipes').select()
-    .then((recipes) => {
-      res.status(200).json(recipes);
-    })
-    .catch((error) => {
-      res.status(500).json({ error });
-    });
-  }
+  knex.schema.hasColumn('recipes', req.query.columnName)
+    .then(validity => {
+    if (validity == true){
+      knex('recipes').orderBy(req.query.columnName, sortOrder)
+      .then((recipes) => {
+        res.status(200).json(recipes);
+      })
+      .catch((error) => {
+        res.status(500).json({ error });
+      });
+    } else {
+      knex('recipes').select()
+      .then((recipes) => {
+        res.status(200).json(recipes);
+      })
+      .catch((error) => {
+        res.status(500).json({ error });
+      });
+    }
+  })
 })
 
 router.get("/food_search", function (req, res, next) {


### PR DESCRIPTION
This PR adds an orderBy query to the GET recipes path.

I've added a couple layers of logic to this search:
- If no params are passed, all recipes are returned in order of id
- If only a column name is passed, results are returned for that column and default order is ascending
- if both params are passed, sort is by relevant column and order
- ~~if either columnName or order are invalid entries, an error will be thrown.~~
EDIT:
- if column name is invalid, sort defaults to Id ascending
- if sort is invalid, defaults to ascending