### PR TITLE
Creates GET api/vi/recipes/average_calories Endpoint

### DIFF
--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -75,7 +75,7 @@ router.get("/food_search", function (req, res, next) {
 })
 
 router.get("/average_calories", function (req, res, next) {
-  knex.select(`${req.query.q}`).from('recipes').avg('caloriesPerServing as average_calories').groupBy(`${req.query.q}`)
+  knex.select(req.query.q).from('recipes').avg('caloriesPerServing as average_calories').groupBy(req.query.q)
   .then(averages => {
     res.status(200).json(averages);
   })

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -74,4 +74,14 @@ router.get("/food_search", function (req, res, next) {
   });
 })
 
+router.get("/average_calories", function (req, res, next) {
+  let average = knex.select(`${req.query.q}`).from('recipes').avg('caloriesPerServing as average_calories').groupBy(`${req.query.q}`)
+  .then(averages => {
+    res.status(200).json(averages);
+  })
+  .catch((error) => {
+    res.status(500).json({ error });
+  });
+})
+
 module.exports = router;

--- a/routes/api/v1/recipes.js
+++ b/routes/api/v1/recipes.js
@@ -75,7 +75,7 @@ router.get("/food_search", function (req, res, next) {
 })
 
 router.get("/average_calories", function (req, res, next) {
-  let average = knex.select(`${req.query.q}`).from('recipes').avg('caloriesPerServing as average_calories').groupBy(`${req.query.q}`)
+  knex.select(`${req.query.q}`).from('recipes').avg('caloriesPerServing as average_calories').groupBy(`${req.query.q}`)
   .then(averages => {
     res.status(200).json(averages);
   })


### PR DESCRIPTION
This pull request creates an endpoint to get the average calories per foodType. This request handles params of the column you would like to group by, so you could also display the average calories by numIngredients if desired. 

Sample request URL: /api/v1/recipes/average_calories?q=foodType

Currently, there is no error message to handle if a column does not exist, however I would imagine that would be handled from a frontend standpoint (not allowing open selection, offering the users specifically listed filters).